### PR TITLE
Update examples-list.component.ts

### DIFF
--- a/app/examples-list.component.ts
+++ b/app/examples-list.component.ts
@@ -13,7 +13,7 @@ var mainMenuLinks = [
     new Link("DatePicker", "/datePickerExamplesComponent"),
     new Link("Dialogs", "/dialogsExamplesComponent"),
     new Link("Layouts", "/layoutsExamplesComponent"),
-    new Link("Ng directives", "/ngDirectivesExamplesComponent"),
+    new Link("*ng directives", "/ngDirectivesExamplesComponent"),
     new Link("TimePicker", "/timePickerExamplesComponent"),
     new Link("ScrollView", "/scrollViewExampleComponent"),
     new Link("SearchBar", "/searchBarExampleComponent"),


### PR DESCRIPTION
This is in order to set the `*ng` directives on top of the list of examples.
