### PR TITLE
chore(deps): pin extract-text-webpack-plugin version to 2.0.0-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "codelyzer": "~2.0.0-beta.3",
         "copy-webpack-plugin": "~3.0.1",
         "css-loader": "~0.26.0",
-        "extract-text-webpack-plugin": "~2.0.0-beta.4",
+        "extract-text-webpack-plugin": "2.0.0-beta.5",
         "fs-extra": "^0.30.0",
         "glob": "^7.0.5",
         "lazy": "1.0.11",


### PR DESCRIPTION
Higher versions require webpack 2.2+, which is not yet supported.