### PR TITLE
Fix ngModel bindings in slider module examples

### DIFF
--- a/app/ui-category/slider/slider-examples.module.ts
+++ b/app/ui-category/slider/slider-examples.module.ts
@@ -1,6 +1,7 @@
 import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 import { NativeScriptModule } from "nativescript-angular/nativescript.module";
+import { NativeScriptFormsModule } from "nativescript-angular/forms";
 import { SliderExamplesComponent } from "./slider-examples.component";
 import { BasicSliderComponent } from "./basic-slider/basic-slider.component";
 import { SliderAccessValueComponent } from "./slider-access-value-code/slider-access-value.component";
@@ -28,6 +29,7 @@ export const routerConfig = [
     imports: [
         TitleAndNavButtonModule,
         NativeScriptModule,
+        NativeScriptFormsModule,
         NativeScriptRouterModule,
         NativeScriptRouterModule.forChild(routerConfig)
     ],


### PR DESCRIPTION
Slider module is missing reference to NativeScriptFormsModule so all ngModel bindings in slider examples do not work.