### PR TITLE
added example for auto closeCallback

### DIFF
--- a/app/modal-page/sample-modal-page-module-example/modal-view.ts
+++ b/app/modal-page/sample-modal-page-module-example/modal-view.ts
@@ -13,6 +13,12 @@ export class ModalViewComponent implements OnInit {
 
     constructor(private params: ModalDialogParams, private page: Page) {
         this.currentdate = new Date(params.context);
+
+        this.page.on("unloaded", () => {
+            // using the unloaded event to close the modal when there is user interaction
+            // e.g. user taps outside the modal page
+            this.params.closeCallback();
+        });
     }
 
     ngOnInit() {


### PR DESCRIPTION
added example for auto closeCallback when there is no interaction in the modal page

Related to [https://github.com/NativeScript/NativeScript/issues/4445](https://github.com/NativeScript/NativeScript/issues/4445)