### PR TITLE
Fix code snippet titles

### DIFF
--- a/app/common-screens-category/content-screens/content-scrollable/article.md
+++ b/app/common-screens-category/content-screens/content-scrollable/article.md
@@ -1,9 +1,9 @@
 Content page with paralax scrolling effect
 
-HTML
+TypeScript
 <snippet id='content-paralax-page-code'/>
 
-TypeScript
+HTML
 <snippet id='content-paralax-page-html'/>
 
 


### PR DESCRIPTION
The TypeScript and HTML titles were switched for their code snippets.