### PR TITLE
fix(webpack-ios): require "nativescript-angular/platform" first in vendor.ts

### DIFF
--- a/app/vendor.ts
+++ b/app/vendor.ts
@@ -8,8 +8,8 @@ require("@angular/forms");
 require("@angular/http");
 require("@angular/router");
 
-require("nativescript-angular/animations");
 require("nativescript-angular/platform-static");
+require("nativescript-angular/animations");
 require("nativescript-angular/router");
 require("nativescript-angular/forms");
 


### PR DESCRIPTION
"nativescript-angular/platform-static" should be the first imported module from "nativescript-angular" because of: https://github.com/NativeScript/nativescript-angular/blob/master/nativescript-angular/platform-common.ts#L3-L4.

fixes https://github.com/NativeScript/nativescript-dev-webpack/issues/260