### PR TITLE
[DO NOT MERGE] chore: use nativescript-camera with ~

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@angular/platform-browser-dynamic": "~6.1.0",
     "@angular/router": "~6.1.0",
     "nativescript-angular": "^6.2.0",
-    "nativescript-camera": "^4.0.2",
+    "nativescript-camera": "~4.0.2",
     "nativescript-geolocation": "^4.3.0",
     "nativescript-intl": "~3.0.0",
     "nativescript-theme-core": "^1.0.4",


### PR DESCRIPTION
I think nativescript-camera@4.1 case some issues.
This is test to verify it will work with 4.0.*