### PR TITLE
chore: version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,45 +22,42 @@
   "nativescript": {
     "id": "org.nativescript.nativescriptsdkexamplesng",
     "tns-android": {
-      "version": "5.0.0"
-    },
-    "tns-ios": {
-      "version": "5.0.0"
+      "version": "5.1.0"
     }
   },
   "dependencies": {
-    "@angular/common": "~7.0.0",
-    "@angular/compiler": "~7.0.0",
-    "@angular/core": "~7.0.0",
-    "@angular/forms": "~7.0.0",
-    "@angular/http": "~7.0.0",
-    "@angular/platform-browser": "~7.0.0",
-    "@angular/platform-browser-dynamic": "~7.0.0",
-    "@angular/router": "~7.0.0",
-    "nativescript-angular": "^7.0.2",
+    "@angular/common": "~7.1.0",
+    "@angular/compiler": "~7.1.0",
+    "@angular/core": "~7.1.0",
+    "@angular/forms": "~7.1.0",
+    "@angular/http": "~7.1.0",
+    "@angular/platform-browser": "~7.1.0",
+    "@angular/platform-browser-dynamic": "~7.1.0",
+    "@angular/router": "~7.1.0",
+    "nativescript-angular": "^7.1.0",
     "nativescript-camera": "^4.1.1",
     "nativescript-geolocation": "^4.3.1",
     "nativescript-intl": "~3.0.0",
     "nativescript-theme-core": "^1.0.4",
     "reflect-metadata": "~0.1.12",
     "rxjs": "^6.3.3",
-    "tns-core-modules": "^5.0.5",
-    "zone.js": "^0.8.26"
+    "tns-core-modules": "^5.1.1",
+    "zone.js": "^0.8.4"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "~7.0.0",
-    "@ngtools/webpack": "~7.0.0",
+    "@angular/compiler-cli": "~7.1.0",
+    "@ngtools/webpack": "~7.1.0",
     "codelyzer": "^3.0.1",
     "fs-extra": "^0.30.0",
     "glob": "^7.1.3",
     "lazy": "1.0.11",
     "markdown-snippet-injector": "^0.2.2",
-    "nativescript-dev-typescript": "^0.7.6",
-    "nativescript-dev-webpack": "^0.18.0",
+    "nativescript-dev-typescript": "^0.7.8",
+    "nativescript-dev-webpack": "^0.18.5",
     "opener": "^1.4.1",
     "rimraf": "^2.5.3",
     "tar.gz": "^1.0.5",
-    "tns-platform-declarations": "^5.0.5",
+    "tns-platform-declarations": "^5.1.1",
     "tslint": "^5.11.0",
     "typescript": "~3.1.1"
   },


### PR DESCRIPTION
Version bump to latest - before merge notice that uglifying is not passing (before and after version bumps) due to the error logged here: https://github.com/NativeScript/nativescript-sdk-examples-ng/issues/347