### PR TITLE
fix a little copy&paste error

### DIFF
--- a/app/ng-framework-modules-category/platform/platform-module-example/platform-module-example.ts
+++ b/app/ng-framework-modules-category/platform/platform-module-example/platform-module-example.ts
@@ -41,7 +41,7 @@ export class PlatformModuleExampleComponent {
     constructor() {
         this.deviceInformation = new DeviceInfo(
             device.model,
-            device.model,
+            device.deviceType,
             device.os,
             device.osVersion,
             device.sdkVersion,


### PR DESCRIPTION
In `deviceInformation` there was `device.model` two times instead of `device.deviceType`