### PR TITLE
fix: Add note about dynamic style loading

### DIFF
--- a/app/ng-ui-widgets-category/style/apply-style-via-code/article.md
+++ b/app/ng-ui-widgets-category/style/apply-style-via-code/article.md
@@ -1,2 +1,4 @@
 Dynamically added styles
 <snippet id='setting-style-via-code'/>
+
+NOTE: Starting with v4.1, this is not functional in your `app.component.ts`. [See the release announcement for more details](https://www.nativescript.org/blog/announcing-the-nativescript-4.1-release)


### PR DESCRIPTION
The documentation's article on dynamic style loading doesn't properly denote that it's not possible in an app's `app.component.ts` due to breaking changes introduced in NS 4.1. This PR introduces a note in the documentation that warns about this missing functionality.