### PR TITLE
docs: add Tabs/BottomNavigaiton styling options

### DIFF
--- a/app/ng-ui-widgets-category/bottom-navigation/styling/styling.component.css
+++ b/app/ng-ui-widgets-category/bottom-navigation/styling/styling.component.css
@@ -1,11 +1,9 @@
 /* >> bottom-nav-theming-css-ng */
-TabStripItem.tabstripitem {
-    background-color: teal;
+TabStrip {
+    selected-item-color: blueviolet;
+    un-selected-item-color: brown;
+    highlight-color: gold;
 }
-
-TabStripItem.tabstripitem:active {
-    background-color: yellowgreen;
-} 
 
 TabContentItem.first-tabcontent {
     background-color: seashell;

--- a/app/ng-ui-widgets-category/tabs/styling/article.md
+++ b/app/ng-ui-widgets-category/tabs/styling/article.md
@@ -1,5 +1,13 @@
 > **Note:** - The integration with `nativescript-theme` and the support for custom CSS is currently under development and is on its way.
 
+The main styling options are introduced with three specific properties that should be set on the `TabStrip` component.
+
+- `selectedItemnColor`: Sets the text color of the selected tab strip item. Also sets the color of the tab strip icon when the icon is an icon font (`font://`).
+- `unSelectedItemColor`: Sets the text color of the unselected tab strip items. Also sets the color of the tab strip icon when the icon is an icon font (`font://`).
+- `highlightColor`: Sets the color of the underline for the selected tab strip item.
+
+Those properties can be set dynamically, inline and via CSS.
+
 <snippet id='tabs-theming-css-ng'/>
 
 > **Note:** Currently, we can set only the `backgroundColor`, `color`, `fontFamily`, `fontSize`, `fontStyle`, `fontWeight` and `textTransform` styling properties to the `Label` and `Image` components inside the TabStripItem. More about the usage of those properties can be found in the [Styling]({%slug styling%}#supported-css-properties) article.

--- a/app/ng-ui-widgets-category/tabs/styling/styling.component.css
+++ b/app/ng-ui-widgets-category/tabs/styling/styling.component.css
@@ -1,17 +1,9 @@
 /* >> tabs-theming-css-ng */
-Tabs.bottom-nav {
-    background-color: orangered;
-    color: gold;
-    font-size: 18;
+TabStrip {
+    selected-item-color: blueviolet;
+    un-selected-item-color: brown;
+    highlight-color: gold;
 }
-
-TabStripItem.tabstripitem-active {
-    background-color: teal;
-}
-
-TabStripItem.tabstripitem-active:active {
-    background-color: yellowgreen;
-} 
 
 TabContentItem.first-tabcontent {
     background-color: seashell;
@@ -24,8 +16,5 @@ TabContentItem.second-tabcontent {
 TabContentItem.third-tabcontent {
     background-color: blueviolet;
     color: antiquewhite;
-}
-Tabs TabStrip{
-    highlight-color: red;
 }
 /* << tabs-theming-css-ng */


### PR DESCRIPTION
Tabs styling options revised.
Adds **highlightColor**, **selectedItemColor**, and **unSelectedItemColor** properties example.